### PR TITLE
Add option to set full special attributes support (#267)

### DIFF
--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -85,6 +85,10 @@ if !exists('g:dracula_undercurl')
   let g:dracula_undercurl = g:dracula_underline
 endif
 
+if !exists('g:dracula_full_special_attrs_support')
+  let g:dracula_full_special_attrs_support = has('gui_running')
+endif
+
 if !exists('g:dracula_inverse')
   let g:dracula_inverse = 1
 endif
@@ -111,10 +115,15 @@ function! s:h(scope, fg, ...) " bg, attr_list, special
   let l:attr_list = filter(get(a:, 2, ['NONE']), 'type(v:val) == 1')
   let l:attrs = len(l:attr_list) > 0 ? join(l:attr_list, ',') : 'NONE'
 
-  " Falls back to coloring foreground group on terminals because
-  " nearly all do not support undercurl
+  " If the UI does not have full support for special attributes (like underline and
+  " undercurl) and the highlight does not explicitly set the foreground color,
+  " make the foreground the same as the attribute color to ensure the user will
+  " get some highlight if the attribute is not supported. The default behavior
+  " is to assume that terminals do not have full support, but the user can set
+  " the global variable `g:dracula_full_special_attrs_support` explicitly if the
+  " default behavior is not desirable.
   let l:special = get(a:, 3, ['NONE', 'NONE'])
-  if l:special[0] !=# 'NONE' && l:fg[0] ==# 'NONE' && !has('gui_running')
+  if l:special[0] !=# 'NONE' && l:fg[0] ==# 'NONE' && !g:dracula_full_special_attrs_support
     let l:fg[0] = l:special[0]
     let l:fg[1] = l:special[1]
   endif

--- a/doc/dracula.txt
+++ b/doc/dracula.txt
@@ -1,4 +1,4 @@
-*dracula.txt*           For Vim version 8               Last change: 2018 May 08
+*dracula.txt*           For Vim version 8               Last change: 2021 Oct 22
 *dracula* *vim-dracula*
 
                     |\                          ,,       ~
@@ -85,6 +85,13 @@ Include underline attributes in highlighting >
 * *g:dracula_undercurl*
 Include undercurl attributes in highlighting (only if underline enabled) >
     let g:dracula_undercurl = 1
+
+* *g:dracula_full_special_attrs_support*
+Explicitly declare full support for special attributes. By default it is 1
+for graphical applications and 0 for terminals and terminal emulators.  On
+terminal emulators, set to 1 to allow underline/undercurl highlights without
+changing the foreground color. >
+    let g:dracula_full_special_attrs_support = 1
 
 * *g:dracula_inverse*
 Include inverse attributes in highlighting >


### PR DESCRIPTION
* add option to set full special attributes support

This is useful to inform Dracula that the current UI has full support
for special attributes like underlines and undercurls, as by default it
assumes no terminal emulator have such support.

The default value falls back to the current behavior, assuming only
graphical interfaces have full support.

Fix #266

* fix grammar issues

Co-authored-by: D. Ben Knoble <ben.knoble+github@gmail.com>

* add documentation for the new option

Co-authored-by: D. Ben Knoble <ben.knoble+github@gmail.com>

<!--
If you're fixing a UI issue, make sure you take two screenshots.
One that shows the actual bug and another that shows how you fixed it.
-->

